### PR TITLE
Remove's fusion_hook from builds

### DIFF
--- a/.github/workflows/auxmos.yml
+++ b/.github/workflows/auxmos.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           toolchain: stable
           command: build
-          args: --target i686-pc-windows-msvc --release --features "all_reaction_hooks"
+          args: --target i686-pc-windows-msvc --release --features trit_fire_hook,plasma_fire_hook,generic_fire_hook
       - name: Upload artifact
         uses: actions/upload-artifact@v1
         with:
@@ -52,7 +52,7 @@ jobs:
         with:
           toolchain: stable
           command: build
-          args: --target i686-unknown-linux-gnu --release --features "all_reaction_hooks"
+          args: --target i686-unknown-linux-gnu --release --features trit_fire_hook,plasma_fire_hook,generic_fire_hook
       - name: Upload artifact
         uses: actions/upload-artifact@v1
         with:

--- a/README.md
+++ b/README.md
@@ -6,5 +6,7 @@ This code relies on some byond code on [this fork of Citadel](https://github.com
 
 The compiled binary on Citadel is compiled for Citadel's CPU, which therefore means that it uses [AVX2 fused-multiply-accumulate](https://en.wikipedia.org/wiki/Advanced_Vector_Extensions#Advanced_Vector_Extensions_2). Yes, really. If you have issues, compile it yourself, via `cargo rustc --target=i686-pc-windows-msvc --release --features "all_reaction_hooks" -- -C target-cpu=native`.
 
+IMPORTANT: For beecode, `--features "all_reaction_hooks"` will cause problems such as crashing, due to Bee having different fusion code. Replacing that argument with `--features trit_fire_hook,plasma_fire_hook,generic_fire_hook` will prevent auxtools from attempting to hook into fusion procs.
+
 TODO:
 I would quite a lot like monstermos to work.


### PR DESCRIPTION
fusion_hook is not written with our fusion code in mind.

This compiles without that option, making it so that Bee's fusion is ran in the old DM code, as it did under extools. 